### PR TITLE
Tokenize all pseudoclasscolons, rather than just the first.

### DIFF
--- a/cssmin.js
+++ b/cssmin.js
@@ -233,8 +233,9 @@ function cssmin(css, linebreakpos) {
     // But, be careful not to turn "p :link {...}" into "p:link{...}"
     // Swap out any pseudo-class colons with the token, and then swap back.
     css = css.replace(/(^|\})(([^\{:])+:)+([^\{]*\{)/g, function (m) {
-        return m.replace(":", "___YUICSSMIN_PSEUDOCLASSCOLON___");
+        return m.replace(/\:/g, "___YUICSSMIN_PSEUDOCLASSCOLON___");
     });
+
     css = css.replace(/\s+([!{};:>+\(\)\],])/g, '$1');
     css = css.replace(/___YUICSSMIN_PSEUDOCLASSCOLON___/g, ":");
 

--- a/tests/files/pseudo.css
+++ b/tests/files/pseudo.css
@@ -1,4 +1,5 @@
-p :link { 
+p :link ,
+div :link {
   ba:zinga;;;
   foo: bar;;;
 }

--- a/tests/files/pseudo.css.min
+++ b/tests/files/pseudo.css.min
@@ -1,1 +1,1 @@
-p :link{ba:zinga;foo:bar}
+p :link,div :link{ba:zinga;foo:bar}


### PR DESCRIPTION
I found a problem with multiple pseudoclasses:

```
a ::pseudoclass,
b ::pseudoclass {}
```

would be minified to:

```
a ::pseudoclass,
b::pseudoclass {}
```

Removing the space in the second instance.

Here's a test and patch for the problem.
Thanks.
